### PR TITLE
Handling the case when the workflow configuration file does not exist

### DIFF
--- a/bin/check_path_lib.py
+++ b/bin/check_path_lib.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+def check_path(inipath):
+    ini_file = Path(inipath)
+    if ini_file.exists() == False:
+        print('File not exists.')
+        exit(1)

--- a/bin/check_path_lib.py
+++ b/bin/check_path_lib.py
@@ -1,7 +1,0 @@
-from pathlib import Path
-
-def check_path(inipath):
-    ini_file = Path(inipath)
-    if ini_file.exists() == False:
-        print('File not exists.')
-        exit(1)

--- a/bin/dhdt.py
+++ b/bin/dhdt.py
@@ -21,6 +21,7 @@ from carst import ConfParams
 from carst.libdhdt import DemPile, onclick_wrapper
 import matplotlib.pyplot as plt
 import numpy as np
+from pathlib import Path
 
 parser = ArgumentParser()
 parser.add_argument('config_file', help='Configuration file')
@@ -30,6 +31,11 @@ args = parser.parse_args()
 # ==== Read ini file ====
 
 inipath = args.config_file
+
+ini_file = Path(inipath)
+if ini_file.exists() == False:
+    print('File not exists.')
+    exit(1)
 
 # ==== Create a DemPile object and load the config file into the object ====
 

--- a/bin/dhdt.py
+++ b/bin/dhdt.py
@@ -22,6 +22,8 @@ from carst.libdhdt import DemPile, onclick_wrapper
 import matplotlib.pyplot as plt
 import numpy as np
 from pathlib import Path
+from check_path_lib import check_path
+
 
 parser = ArgumentParser()
 parser.add_argument('config_file', help='Configuration file')
@@ -31,11 +33,8 @@ args = parser.parse_args()
 # ==== Read ini file ====
 
 inipath = args.config_file
+check_path(inipath)
 
-ini_file = Path(inipath)
-if ini_file.exists() == False:
-    print('File not exists.')
-    exit(1)
 
 # ==== Create a DemPile object and load the config file into the object ====
 

--- a/bin/dhdt.py
+++ b/bin/dhdt.py
@@ -22,7 +22,6 @@ from carst.libdhdt import DemPile, onclick_wrapper
 import matplotlib.pyplot as plt
 import numpy as np
 from pathlib import Path
-from check_path_lib import check_path
 
 
 parser = ArgumentParser()
@@ -33,7 +32,8 @@ args = parser.parse_args()
 # ==== Read ini file ====
 
 inipath = args.config_file
-check_path(inipath)
+ini = ConfParams(inipath)
+ini.check_path()
 
 
 # ==== Create a DemPile object and load the config file into the object ====

--- a/bin/dhdt.py
+++ b/bin/dhdt.py
@@ -21,7 +21,6 @@ from carst import ConfParams
 from carst.libdhdt import DemPile, onclick_wrapper
 import matplotlib.pyplot as plt
 import numpy as np
-from pathlib import Path
 
 
 parser = ArgumentParser()

--- a/bin/featuretrack.py
+++ b/bin/featuretrack.py
@@ -37,6 +37,7 @@ from carst import SingleRaster, RasterVelos, ConfParams
 from carst.libft import ampcor_task, writeout_ampcor_task
 from carst.libxyz import ZArray, DuoZArray, AmpcoroffFile, points_in_polygon
 import numpy as np
+from check_path_lib import check_path
 
 parser = ArgumentParser()
 parser.add_argument('config_file', help='Configuration file')
@@ -46,6 +47,9 @@ args = parser.parse_args()
 # ==== Read ini file ====
 
 inipath = args.config_file
+check_path(inipath)
+
+
 ini = ConfParams(inipath)
 ini.ReadParam()
 ini.VerifyParam()

--- a/bin/featuretrack.py
+++ b/bin/featuretrack.py
@@ -37,7 +37,6 @@ from carst import SingleRaster, RasterVelos, ConfParams
 from carst.libft import ampcor_task, writeout_ampcor_task
 from carst.libxyz import ZArray, DuoZArray, AmpcoroffFile, points_in_polygon
 import numpy as np
-from check_path_lib import check_path
 
 parser = ArgumentParser()
 parser.add_argument('config_file', help='Configuration file')
@@ -47,10 +46,9 @@ args = parser.parse_args()
 # ==== Read ini file ====
 
 inipath = args.config_file
-check_path(inipath)
-
 
 ini = ConfParams(inipath)
+ini.check_path()
 ini.ReadParam()
 ini.VerifyParam()
 

--- a/carst/libconfig.py
+++ b/carst/libconfig.py
@@ -101,6 +101,11 @@ class ConfParams:
         # self.demlist = {}
         # self.regression = {}
         # self.result = {}
+    def check_path(self):
+        ini_file = Path(self.fpath)
+        if ini_file.exists() == False:
+            print('File not exists.')
+            exit(1)
 
     def ReadParam(self):
 


### PR DESCRIPTION
Added a new method `check_path` for the `ConfParams` class to handle the error.